### PR TITLE
feat: add dockerfile config for prod deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,6 @@ EXPOSE 3000
 
 ENV PORT=3000
 
-CMD HOSTNAME="0.0.0.0" node server.js
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM node:20-alpine AS base
+
+# 1. Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat git
+
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+RUN \
+  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i; \
+  else echo "Lockfile not found." && exit 1; \
+  fi
+
+
+# 2. Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+RUN apk add --no-cache git
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# This will do the trick, use the corresponding env file for each environment.
+RUN npm run build
+
+# 3. Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -S nextjs -u 1001
+
+COPY --from=builder /app/public ./public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+CMD HOSTNAME="0.0.0.0" node server.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+docker-build:
+	docker build -f Dockerfile -t jede-app .
+
+docker-run:
+	docker run --rm -p 3000:3000 --env-file .env.local jede-app

--- a/README.md
+++ b/README.md
@@ -81,3 +81,41 @@ export const Default: Story = {
 4. Run Storybook to see your new story in action.
 
 Using Storybook allows for rapid UI development and testing, independent of the backend implementation.
+
+## Docker Deployment
+
+This project includes Docker support for easy deployment on any VPS (Virtual Private Server) or cloud platform.
+
+1. Build the Docker image:
+
+```bash
+docker build -f Dockerfile -t hxckr-web .
+```
+
+2. Run the container:
+
+```bash
+docker run -p 3000:3000 hxckr-web
+```
+
+The app will be available at `http://your-server-ip:3000`.
+
+### Environment Variables
+
+When deploying with Docker, make sure to set up your environment variables. You can do this by:
+
+1. Creating a `.env` file as described in the Getting Started section
+2. Passing environment variables when running the container:
+
+```bash
+docker run -p 3000:3000 \
+  -e GITHUB_ID=your_github_id \
+  -e GITHUB_SECRET=your_github_secret \
+  -e NEXTAUTH_SECRET=your_nextauth_secret \
+  -e NEXTAUTH_URL=http://your-domain.com \
+  -e NEXT_PUBLIC_APP_CORE_BASE_URL=http://your-core-api-url \
+  -e NEXT_PUBLIC_APP_WEBSOCKET_URL=ws://your-websocket-url \
+  hxckr-web
+```
+
+This Docker setup enables easy deployment on any VPS, providing a consistent environment across different hosting platforms.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 import { withContentlayer } from "next-contentlayer2";
 
 const nextConfig = {
+  output: "standalone",
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
This PR adds a dockerfile that can used for deploying the frontend on a VPS.

To test, run:

1. `make docker-build`
2. `make docker-run`

Or you can also follow the instructions highlighted in the updated [README.md](https://github.com/hxckr-org/hxckr-web/pull/15/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)